### PR TITLE
Enhancements/migration logic

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
-    "start": "webpack serve --open"
+    "start": "webpack serve --open",
+    "debug": "npm --node-options=--inspect=0.0.0.0:9229 run start"
   },
   "keywords": [
     "IDBSuit",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
-    "start": "webpack serve"
+    "start": "webpack serve --open"
   },
   "keywords": [
     "IDBSuit",

--- a/examples/webpack/public/index.html
+++ b/examples/webpack/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Webpack</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/examples/webpack/src/config/IDBSuit.js
+++ b/examples/webpack/src/config/IDBSuit.js
@@ -1,15 +1,8 @@
 import { IDBS } from '../PackageSample.js'; // package
 
-// Change your Schema.js path
-import { Schema } from '../db/Schema.js';
-
-// change your migrations/ folder path
-const reqMigrations = require.context('../db/migrations/', true, /\.js$/);
-
-const migrationModules = reqMigrations.keys().map(key => reqMigrations(key));
-
 export default function IDBSuit() {
-  const idbs = new IDBS(Schema, migrationModules);
-  
-  return idbs;
+  const Schema = require('../db/Schema.js');
+  const migrations = require.context('../db/migrations/', true, /\.js$/);
+
+  return new IDBS(Schema, migrations.keys().map(key => migrations(key)));
 }

--- a/examples/webpack/src/db/Schema.js
+++ b/examples/webpack/src/db/Schema.js
@@ -1,4 +1,4 @@
-export const Schema = {
+const Schema = {
   dbName: "slickPickDB",
   version: 1714815400413,
   tables: [
@@ -36,3 +36,4 @@ export const Schema = {
     },
   ],
 };
+module.exports = Schema;

--- a/examples/webpack/src/index.js
+++ b/examples/webpack/src/index.js
@@ -1,17 +1,11 @@
 import IDBSuit from './config/IDBSuit.js'
 class App {
   constructor() {
-    this.message = 'Hello, ES6!';
+    this.db = IDBSuit();
   }
 
   displayDB() {
-    console.log(this.message);
-
-    const idbs = IDBSuit();
-
-    console.log(idbs);
-
-    idbs.openDatabase()
+    this.db.openDatabase()
       .then(dbInstance => {
         document.getElementById('root').innerText = 'DB Version '+dbInstance.version;
       })
@@ -19,7 +13,7 @@ class App {
         console.error('Error opening database:', error);
       });
 
-    // idbs.destroy()
+    // this.db.destroy()
     //   .then(() => {
     //     console.log('Database deleted successfully');
     //   })

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -5,12 +5,12 @@ module.exports = {
     output: {
         filename: 'main.js',
         path: path.resolve(__dirname, 'dist'),
+        clean: true,
     },
     mode: 'development',
     devServer: {
-        static: {
-            directory: path.resolve(__dirname, 'dist'),
-        },
+        static: path.join(__dirname, 'public'),
+        compress: true,
         port: 3000,
         allowedHosts: 'all',
         open: true,

--- a/src/Migration.ts
+++ b/src/Migration.ts
@@ -1,4 +1,4 @@
-export default class Migration {
+export default abstract class Migration {
   static derivedClasses: Array<[string, number]> = [];
 
   protected dbInstance: IDBDatabase;
@@ -8,6 +8,8 @@ export default class Migration {
   }
 
   static newVersion(version: number): void {
-    this.derivedClasses.push([this.name, version]); // record class name and version
+    this.derivedClasses.push([this.name, version]);
   }
+
+  abstract migrate(): void;
 }


### PR DESCRIPTION
- Convert class into abstract Migration class and create abstract migrate() method
- When the `request.onupgradeneeded` throws an error then the version is upgraded but migrations/createTables are not applied.
    - Upgrade in transaction on previous version first
- Add schema and migration validation